### PR TITLE
Sanitize matrix field blocks and fields before assigning

### DIFF
--- a/src/elements/Block.php
+++ b/src/elements/Block.php
@@ -35,6 +35,12 @@ class Block extends Element
     {
         // Filter out any field values for fields that no longer exist on the element
         foreach ($values as $fieldHandle => $value) {
+            $field = $this->fieldByHandle($fieldHandle);
+
+            if (Matrix::isMatrix($field)) {
+                $values[$fieldHandle] = Matrix::sanitizeMatrixContent($field, $value);
+            }
+
             if (!property_exists($this->getBehavior('customFields'), $fieldHandle)) {
                 unset($values[$fieldHandle]);
             }

--- a/src/elements/Block.php
+++ b/src/elements/Block.php
@@ -1,6 +1,8 @@
 <?php
 namespace verbb\vizy\elements;
 
+use verbb\vizy\helpers\Matrix;
+
 use Craft;
 use craft\base\Element;
 

--- a/src/helpers/Matrix.php
+++ b/src/helpers/Matrix.php
@@ -1,0 +1,45 @@
+<?php
+namespace verbb\vizy\helpers;
+
+use verbb\vizy\Vizy;
+
+use Craft;
+
+class Matrix
+{
+    public static function sanitizeMatrixContent($field, $content)
+    {
+        $blockTypes = array_map(function ($block) {
+            return $block->handle;
+        }, $field->blockTypes);
+
+        $blockFields = array_map(function ($block) {
+            return $block->handle;
+        }, $field->blockTypeFields);
+
+        if (array_key_exists('blocks', $content)) {
+            // Filter block types against those available
+            $content['blocks'] = array_filter($content['blocks'], function ($block) use ($blockTypes) {
+                return in_array($block['type'], $blockTypes);
+            });
+
+            // Filter fields within valid blocks against those available
+            $content['blocks'] = array_map(function ($block) use ($blockFields) {
+                if (array_key_exists('fields', $block)) {
+                    $block['fields'] = array_filter($block['fields'], function ($key) use ($blockFields) {
+                        return in_array($key, $blockFields);
+                    }, ARRAY_FILTER_USE_KEY);
+                }
+
+                return $block;
+            }, $content['blocks']);
+        }
+
+        return $content;
+    }
+
+    public static function isMatrix($field)
+    {
+        return $field instanceof craft\fields\Matrix;
+    }
+}

--- a/src/nodes/VizyBlock.php
+++ b/src/nodes/VizyBlock.php
@@ -251,6 +251,10 @@ class VizyBlock extends Node
 
         $content = $this->_getRawFieldContent($fieldHandle);
 
+        if (Matrix::isMatrix($field)) {
+            $content = Matrix::sanitizeMatrixContent($field, $content);
+        }
+
         return $this->_normalizedFieldValues[$fieldHandle] = $field->normalizeValue($content, $this->element);
     }
 

--- a/src/nodes/VizyBlock.php
+++ b/src/nodes/VizyBlock.php
@@ -3,6 +3,7 @@ namespace verbb\vizy\nodes;
 
 use verbb\vizy\base\Node;
 use verbb\vizy\elements\Block as BlockElement;
+use verbb\vizy\helpers\Matrix;
 
 use Craft;
 use craft\base\ElementInterface;


### PR DESCRIPTION
The issue I encountered in #49 was pretty awkward to get around short of deleting all of my entries containing the affected field. I'm sure this code will want cleaning up but the following code prevents the issue I was encountering from occurring (both on the frontend and the backend code editor).

Loading each field with `fieldByHandle` in src/elements/Block.php isn't a particularly elegant solution.

Hope it helps in merging a long-term fix.