### PR TITLE
Set onload to null

### DIFF
--- a/src/helpers/Plugin.php
+++ b/src/helpers/Plugin.php
@@ -17,7 +17,7 @@ class Plugin
             'depends' => [
                 VizyAsset::class,
             ],
-            'onload' => '',
+            'onload' => null,
         ];
 
         $styleOptions = [


### PR DESCRIPTION
Removes attribute from tag completely.

Embed plugin with `null` compared to Vizy with an empty string.

<img width="1080" alt="Screen Shot 2022-08-23 at 11 27 35 pm" src="https://user-images.githubusercontent.com/25124/186170306-7f5e77fb-620b-4ade-81d7-aa01936d9b5d.png">

