### PR TITLE
fix: bug importing empty nodes into vizy field via feed-me feed

### DIFF
--- a/src/integrations/feedme/fields/Vizy.php
+++ b/src/integrations/feedme/fields/Vizy.php
@@ -39,7 +39,7 @@ class Vizy extends Field implements FieldInterface
      */
     public function parseField(): string
     {
-        $value = $this->fetchValue();
+        $value = $this->fetchValue() ?? [ 'content' => '' ];
 
         $editor = new Editor([
             'content' => $value,


### PR DESCRIPTION
Fiddling around a little bit, I managed to fix #189 with this simple change.

It might not be the best way to address empty nodes from imported feeds, but it prevents the `Trying to access array offset on value of type null` error and proceeds with importing the rest of the data, leaving the Vizy text empty?